### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -236,7 +236,7 @@ app.post('/api/tools', async (req: Request, res: Response) => {
       const toolName = req.body.params?.name;
       const args = req.body.params?.arguments || {};
       
-      console.log(`MCP tools/call - Tool: ${toolName}, Args:`, args);
+      console.log("MCP tools/call - Tool: %s, Args:", toolName, args);
 
       if (!toolName) {
         return res.status(400).json({


### PR DESCRIPTION
Potential fix for [https://github.com/comeredon/mymcp/security/code-scanning/1](https://github.com/comeredon/mymcp/security/code-scanning/1)

In general, to fix this kind of issue you should avoid embedding untrusted data directly into the format string argument of functions that interpret `%`-style specifiers (such as `console.log` / `util.format`). Instead, use a constant format string and pass untrusted data as subsequent arguments, or sanitize/escape any `%` characters in the untrusted data before interpolation.

The best fix here, without changing functionality, is to modify the `console.log` call on line 239 so that the first argument is a constant string, and `toolName` is passed as a separate argument to be formatted with a `%s` placeholder. This preserves the existing logging behavior (logging the tool name and args) while ensuring that any `%` characters in `toolName` cannot be interpreted as format specifiers. Concretely, in `src/server.ts`, replace:

```ts
console.log(`MCP tools/call - Tool: ${toolName}, Args:`, args);
```

with:

```ts
console.log("MCP tools/call - Tool: %s, Args:", toolName, args);
```

No new imports or helper methods are required; this uses Node’s built-in `console.log` formatting semantics. All other logic and behavior remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
