### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -378,7 +378,7 @@ app.post('/api/tools', async (req: Request, res: Response) => {
       });
     }
 
-    console.log(`Legacy format - Tool: ${tool}, Args:`, args);
+    console.log("Legacy format - Tool: %s, Args:", tool, args);
 
     // Handle legacy format requests
     switch (tool.toLowerCase()) {


### PR DESCRIPTION
Potential fix for [https://github.com/comeredon/mymcp/security/code-scanning/2](https://github.com/comeredon/mymcp/security/code-scanning/2)

In general, the fix is to ensure untrusted data is not used as part of the format string itself. Instead, pass a constant format string (or at least one that is not influenced by user input) as the first argument, and include untrusted data only as later arguments, typically bound via `%s` placeholders or as separate arguments.

For this specific case in `src/server.ts`, the best fix without changing functionality is to change the `console.log` call on line 381 so that the first argument is a constant string and `tool` is passed separately. The logged information should remain the same: we still want to log that this is a legacy format, the tool name, and the arguments object. A good replacement is:
```ts
console.log("Legacy format - Tool: %s, Args:", tool, args);
```
This preserves the structure of the log output, avoids using a tainted value in the format string, and does not require any new imports or helper functions. Only the single line containing the `console.log` needs to be changed within `src/server.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
